### PR TITLE
✅ Bug Fixed:

### DIFF
--- a/src/scripts/score.py
+++ b/src/scripts/score.py
@@ -88,8 +88,6 @@ def init():
             # Create a basic preprocessor instance for fallback
             preprocessor = None
             logger.info("Will use fallback preprocessing for all requests")
-        preprocessor = PurchaseDataPreprocessor.load_fitted_preprocessor()
-        logger.info("Preprocessor loaded successfully")
             
     except Exception as e:
         logger.error(f"Error loading model: {str(e)}")


### PR DESCRIPTION
What was removed:

Line 91: preprocessor = PurchaseDataPreprocessor.load_fitted_preprocessor() (redundant call)
Line 92: logger.info("Preprocessor loaded successfully") (misleading log message)
Why this fix is correct:

Preserves exception handling logic - The careful try/catch block now works as intended
Prevents double failure - Won't attempt the same failing call twice
Maintains fallback behavior - If loading fails, preprocessor = None stays set for fallback processing
Eliminates misleading logs - Won't log "success" when preprocessing actually failed
The corrected flow:

Try to load the fitted preprocessor
If successful: preprocessor contains the loaded object, log success
If failed: preprocessor = None, log the failure and fallback message
Continue with initialization using appropriate preprocessor state
This fix ensures the scoring script will gracefully handle preprocessor loading failures and fall back to the manual preprocessing logic as intended! 🎉